### PR TITLE
Recursion tracking in deep comparisons.

### DIFF
--- a/src/DeepEqual/ComparedObjectHash.cs
+++ b/src/DeepEqual/ComparedObjectHash.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DeepEqual {
+	public class ComparedObjectHash : IEqualityComparer<Tuple<object, object>> {
+		private readonly HashSet<Tuple<object, object>> set;
+
+		public ComparedObjectHash()
+		{
+			set = new HashSet<Tuple<object, object>>(this);
+		}
+
+		public bool Enabled { get; set; }
+
+		/// <summary>
+		/// Adds an object to the hash, and returns true if the object has yet to be visited.
+		/// If the hash is disabled, always returns true.
+		/// </summary>
+		public bool Add(object item1, object item2)
+		{
+			if (!Enabled)
+			{
+				return true;
+			}
+
+			return set.Add(new Tuple<object, object>(item1, item2));
+		}
+
+		public bool Equals(Tuple<object, object> x, Tuple<object, object> y) {
+			return ReferenceEquals(x.Item1, y.Item1)
+				&& ReferenceEquals(x.Item2, y.Item2);
+		}
+
+		public int GetHashCode(Tuple<object, object> obj) {
+			// This value may not be ideal when objects override GetHashCode and Equals, but it will still work.
+			return obj.Item1.GetHashCode() ^ obj.Item2.GetHashCode();
+		}
+	}
+}

--- a/src/DeepEqual/ComparisonContext.cs
+++ b/src/DeepEqual/ComparisonContext.cs
@@ -5,6 +5,7 @@
 
 	public class ComparisonContext : IComparisonContext
 	{
+		public ComparedObjectHash ComparedObjectHash { get; private set; }
 		public List<Difference> Differences { get; private set; }
 		public string Breadcrumb { get; private set; }
 
@@ -12,8 +13,11 @@
 
 		public ComparisonContext(string breadcrumb) : this(null, breadcrumb) {}
 
-		public ComparisonContext(List<Difference> differences, string breadcrumb)
+		public ComparisonContext(List<Difference> differences, string breadcrumb) : this(differences, breadcrumb, null) {}
+
+		public ComparisonContext(List<Difference> differences, string breadcrumb, ComparedObjectHash hash)
 		{
+			ComparedObjectHash = hash ?? new ComparedObjectHash();
 			Differences = differences ?? new List<Difference>();
 			Breadcrumb = breadcrumb;
 		}
@@ -23,18 +27,29 @@
 			Differences.Add(difference);
 		}
 
+		public bool RecursionProtection
+		{
+			get { return ComparedObjectHash.Enabled; }
+			set { ComparedObjectHash.Enabled = value; }
+		}
+
+		public bool VisitObjects(object item1, object item2)
+		{
+			return ComparedObjectHash.Add(item1, item2);
+		}
+
 		public IComparisonContext VisitingProperty(string propertyName)
 		{
 			var newBreadcrumb = string.Format("{0}.{1}", Breadcrumb, propertyName);
 
-			return new ComparisonContext(Differences, newBreadcrumb);
+			return new ComparisonContext(Differences, newBreadcrumb, ComparedObjectHash);
 		}
 
 		public IComparisonContext VisitingIndex(object index)
 		{
 			var newBreadcrumb = string.Format(CultureInfo.InvariantCulture, "{0}[{1}]", Breadcrumb, index);
 
-			return new ComparisonContext(Differences, newBreadcrumb);
+			return new ComparisonContext(Differences, newBreadcrumb, ComparedObjectHash);
 		}
 
 		public override string ToString()

--- a/src/DeepEqual/ComparisonContext.cs
+++ b/src/DeepEqual/ComparisonContext.cs
@@ -33,7 +33,7 @@
 			set { ComparedObjectHash.Enabled = value; }
 		}
 
-		public bool VisitObjects(object item1, object item2)
+		public bool ShouldVisitObjects(object item1, object item2)
 		{
 			return ComparedObjectHash.Add(item1, item2);
 		}

--- a/src/DeepEqual/ComplexObjectComparison.cs
+++ b/src/DeepEqual/ComplexObjectComparison.cs
@@ -25,7 +25,7 @@
 
 		public ComparisonResult Compare(IComparisonContext context, object value1, object value2)
 		{
-			if (!context.VisitObjects(value1, value2))
+			if (!context.ShouldVisitObjects(value1, value2))
 			{
 				return ComparisonResult.Pass;
 			}

--- a/src/DeepEqual/ComplexObjectComparison.cs
+++ b/src/DeepEqual/ComplexObjectComparison.cs
@@ -25,6 +25,11 @@
 
 		public ComparisonResult Compare(IComparisonContext context, object value1, object value2)
 		{
+			if (!context.VisitObjects(value1, value2))
+			{
+				return ComparisonResult.Pass;
+			}
+
 			var comparer = new ComplexObjectComparer(Inner, IgnoreUnmatchedProperties, IgnoredProperties);
 
 			return comparer.CompareObjects(context, value1, value2);

--- a/src/DeepEqual/DeepEqual.csproj
+++ b/src/DeepEqual/DeepEqual.csproj
@@ -36,6 +36,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ComparedObjectHash.cs" />
     <Compile Include="ComparisonBuilder.cs" />
     <Compile Include="ComparisonContext.cs" />
     <Compile Include="ComparisonResult.cs" />

--- a/src/DeepEqual/IComparisonContext.cs
+++ b/src/DeepEqual/IComparisonContext.cs
@@ -11,5 +11,6 @@
 
 		IComparisonContext VisitingProperty(string propertyName);
 		IComparisonContext VisitingIndex(object index);
+		bool ShouldVisitObjects(object item1, object item2);
 	}
 }

--- a/src/DeepEqual/Syntax/ObjectExtensions.cs
+++ b/src/DeepEqual/Syntax/ObjectExtensions.cs
@@ -7,33 +7,37 @@
 	public static class ObjectExtensions
 	{
 		[Pure]
-		public static bool IsDeepEqual(this object actual, object expected)
+		public static bool IsDeepEqual(this object actual, object expected, bool recursionProtection = true)
 		{
 			var comparison = new ComparisonBuilder().Create();
 
-			return IsDeepEqual(actual, expected, comparison);
+			return IsDeepEqual(actual, expected, comparison, recursionProtection);
 		}
 
 		[Pure]
-		public static bool IsDeepEqual(this object actual, object expected, IComparison comparison)
+		public static bool IsDeepEqual(this object actual, object expected, IComparison comparison, bool recursionProtection = true)
 		{
-			var context = new ComparisonContext();
+			var context = new ComparisonContext {
+				RecursionProtection = recursionProtection
+			};
 
 			var result = comparison.Compare(context, actual, expected);
 
 			return result == ComparisonResult.Pass;
 		}
 
-		public static void ShouldDeepEqual(this object actual, object expected)
+		public static void ShouldDeepEqual(this object actual, object expected, bool recursionProtection = true)
 		{
 			var comparison = new ComparisonBuilder().Create();
 
-			ShouldDeepEqual(actual, expected, comparison);
+			ShouldDeepEqual(actual, expected, comparison, recursionProtection);
 		}
 
-		public static void ShouldDeepEqual(this object actual, object expected, IComparison comparison)
+		public static void ShouldDeepEqual(this object actual, object expected, IComparison comparison, bool recursionProtection = true)
 		{
-			var context = new ComparisonContext();
+			var context = new ComparisonContext {
+				RecursionProtection = recursionProtection
+			};
 
 			var result = comparison.Compare(context, actual, expected);
 


### PR DESCRIPTION
- Add an option, on by default, to track recursion in objects and skip them when we encounter the same pair of objects again within themselves.

Note that we use object.ReferenceEquals for comparison, so this would not work for value types, but it would still work for reference types and a recursive loop is impossible without at least some reference types. This handles circumstances where two objects' .Equals method returns the same ignoring parameters which aren't the same.
