### PR TITLE
String comparison bug

### DIFF
--- a/src/DeepEqual.Test/ExceptionMessageTests.cs
+++ b/src/DeepEqual.Test/ExceptionMessageTests.cs
@@ -1,4 +1,6 @@
-﻿namespace DeepEqual.Test
+﻿using Xunit.Extensions;
+
+namespace DeepEqual.Test
 {
 	using System.Collections.Generic;
 
@@ -114,6 +116,23 @@ Comparison Failed: The following 1 differences were found.
 			AssertExceptionMessage(context, @"
 Comparison Failed: The following 1 differences were found.
 	Actual != Expected (""...45678901234567890123"" != ""...01234567890123456789"")");
+		}
+
+		[Theory]
+		[InlineData("0123456789012345678", "01234567890123456789", "0123456789012345678", "01234567890123456789")]
+		[InlineData("012345678901234567", "0123456789012345678", "012345678901234567", "0123456789012345678")]
+		[InlineData("0123456789012345678", "012345678901234567890", "0123456789012345678", "...12345678901234567890")]
+		[InlineData("012345678901234567890", "0123456789012345678", "...12345678901234567890", "0123456789012345678")]
+		public void Strings_around_same_length_as_max_length(string value1, string value2, string expected1, string expected2)
+		{
+			var context = new ComparisonContext();
+			context.AddDifference(
+				value1,
+				value2);
+
+			AssertExceptionMessage(context, string.Format(@"
+Comparison Failed: The following 1 differences were found.
+	Actual != Expected (""{0}"" != ""{1}"")", expected1, expected2));
 		}
 
 		[Fact]

--- a/src/DeepEqual/Formatting/BasicDifferenceFormatter.cs
+++ b/src/DeepEqual/Formatting/BasicDifferenceFormatter.cs
@@ -5,6 +5,8 @@ namespace DeepEqual.Formatting
 
 	public class BasicDifferenceFormatter : DifferenceFormatterBase
 	{
+		private const int InitialMaxLength = 20;
+
 		public override string Format(Difference difference)
 		{
 			var format = "Actual{0}.{1} != Expected{0}.{1} ({2} != {3})";
@@ -28,7 +30,8 @@ namespace DeepEqual.Formatting
 
 		private void FixLongStringDifference(ref object v1, ref object v2)
 		{
-			var maxLength = 20;
+			var maxLength1 = InitialMaxLength;
+			var maxLength2 = InitialMaxLength;
 
 			var value1 = (string) v1;
 			var value2 = (string) v2;
@@ -39,13 +42,21 @@ namespace DeepEqual.Formatting
 
 			if (lowerBound >= 3)
 			{
-				value1 = "..." + value1.Substring(Math.Min(lowerBound, value1.Length - maxLength));
-				value2 = "..." + value2.Substring(Math.Min(lowerBound, value2.Length - maxLength));
-				maxLength += 3;
+				if (value1.Length > maxLength1)
+				{
+					value1 = "..." + value1.Substring(Math.Min(lowerBound, value1.Length - maxLength1));
+					maxLength1 += 3;
+				}
+
+				if (value2.Length > maxLength2)
+				{
+					value2 = "..." + value2.Substring(Math.Min(lowerBound, value2.Length - maxLength2));
+					maxLength2 += 3;
+				}
 			}
 
-			if (value1.Length > maxLength + 3) value1 = value1.Substring(0, maxLength) + "...";
-			if (value2.Length > maxLength + 3) value2 = value2.Substring(0, maxLength) + "...";
+			if (value1.Length > maxLength1 + 3) value1 = value1.Substring(0, maxLength1) + "...";
+			if (value2.Length > maxLength2 + 3) value2 = value2.Substring(0, maxLength2) + "...";
 
 			v1 = value1;
 			v2 = value2;


### PR DESCRIPTION
Strings close to 20 characters with differences at the end causes the comparison to throw:

> System.ArgumentOutOfRangeException : StartIndex cannot be less than zero.

This PR fixes that issue.