### PR TITLE
Add net461 target to work around ValueTuple missing method exceptions

### DIFF
--- a/src/DeepEqual/DeepEqual.csproj
+++ b/src/DeepEqual/DeepEqual.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net462;netcoreapp2.1</TargetFrameworks>
 
     <Version>2.0.0</Version>
     <Description>An extensible deep comparison library for .NET</Description>

--- a/src/DeepEqual/DeepEqual.csproj
+++ b/src/DeepEqual/DeepEqual.csproj
@@ -24,11 +24,11 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections.Immutable" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
See dotnet/standard#567 for context here, in particular this comment:
https://github.com/dotnet/standard/issues/567#issuecomment-341615176

I ran into this while using `SetComparison.Compare(...)` which is all public DeepEquals API. This manifests itself like so:
```c#
	[{System.MissingMethodException}: 'Method not found: 'System.ValueTuple`2<DeepEqual.ComparisonResult,DeepEqual.IComparisonContext> DeepEqual.SetComparison.Compare(DeepEqual.IComparisonContext, System.Object, System.Object)'.']
```
(The only sensible alternative to this is probably to avoid using `System.ValueTuple` in your public API.)