### PR TITLE
Fix differences duplication in dict compare

### DIFF
--- a/src/DeepEqual/DictionaryComparison.cs
+++ b/src/DeepEqual/DictionaryComparison.cs
@@ -59,7 +59,7 @@
 				var value = dict2[key];
 				dict2.Remove(key);
 
-				var (result, innerContext) = ValueComparer.Compare(context.VisitingIndex(key), entry.Value, value);
+				var (result, innerContext) = ValueComparer.Compare(new ComparisonContext($"{(object) context.Breadcrumb}[{key}]"), entry.Value, value);
 
 				results.Add(result);
 				context = context.MergeDifferencesFrom(innerContext);


### PR DESCRIPTION
`.VisitingIndex` makes a copy of the entire context, which then gets merged with the same original context, duplicating the `Differences`. In case a difference was detected at the start of a dictionary, you end up with `2^keys` amount of duplicate differences.

Fix this by creating a new empty context for the inner comparison.