### PR TITLE
Fix incorrect comparison for value types containing reference fields

### DIFF
--- a/src/DeepEqual.Test/DeepComparisonTest.cs
+++ b/src/DeepEqual.Test/DeepComparisonTest.cs
@@ -128,6 +128,24 @@
 
 			Approvals.Verify(exception.Message);
 		}
+
+		[Fact]
+		public void AssertOnTuple()
+		{
+			var left = new KeyValuePair<string, object>("1", new Model { Id = 10, Name = "1" });
+			var right = new KeyValuePair<string, object>("1", new Model { Id = 10, Name = "1" });
+			var left_struct = new KeyValuePair<string, int>("1", 1);
+			var right_struct = new KeyValuePair<string, int>("1", 1);
+
+			DeepAssert.AreEqual(left, right);
+			DeepAssert.AreEqual(left_struct, right_struct);
+		}
+
+		public class Model
+        {
+			public int Id { get; set;}
+			public string Name { get; set; }
+        }
 	}
 
 	public class TestType 

--- a/src/DeepEqual.Test/DeepComparisonTest.cs
+++ b/src/DeepEqual.Test/DeepComparisonTest.cs
@@ -142,10 +142,10 @@
 		}
 
 		public class Model
-        {
+		{
 			public int Id { get; set;}
 			public string Name { get; set; }
-        }
+		}
 	}
 
 	public class TestType

--- a/src/DeepEqual/ComplexObjectComparison.cs
+++ b/src/DeepEqual/ComplexObjectComparison.cs
@@ -20,7 +20,9 @@
 
 		public bool CanCompare(Type type1, Type type2)
 		{
-			return type1.IsClass && type2.IsClass;
+			return (type1.IsClass && type2.IsClass) 
+				|| ReflectionCache.IsValueTypeWithReferenceFields(type1) 
+				|| ReflectionCache.IsValueTypeWithReferenceFields(type2);
 		}
 
 		public (ComparisonResult result, IComparisonContext context) Compare(IComparisonContext context, object value1, object value2)

--- a/src/DeepEqual/DefaultComparison.cs
+++ b/src/DeepEqual/DefaultComparison.cs
@@ -16,7 +16,9 @@
 
 		public bool CanCompare(Type type1, Type type2)
 		{
-			return !IsSkipped(type1) && !IsSkipped(type2);
+			return !IsSkipped(type1) && !IsSkipped(type2)
+				&& !ReflectionCache.IsValueTypeWithReferenceFields(type1)
+				&& !ReflectionCache.IsValueTypeWithReferenceFields(type2);
 		}
 
 		public (ComparisonResult result, IComparisonContext context) Compare(IComparisonContext context, object value1, object value2)

--- a/src/DeepEqual/ReflectionCache.cs
+++ b/src/DeepEqual/ReflectionCache.cs
@@ -26,6 +26,8 @@ namespace DeepEqual
 			= new ConcurrentDictionary<Type, bool>();
 		private static readonly ConcurrentDictionary<Type, PropertyReader[]> PropertyCache
 			= new ConcurrentDictionary<Type, PropertyReader[]>();
+		private static readonly ConcurrentDictionary<Type, bool> ValueTypeWithReferenceFieldsCache
+			= new ConcurrentDictionary<Type, bool>();
 
 		public static void ClearCache()
 		{
@@ -65,7 +67,18 @@ namespace DeepEqual
 			return implements.GetGenericArguments()[0];
 		}
 
-		internal static bool IsListType(Type type)
+		internal static bool IsValueTypeWithReferenceFields(Type type)
+        {
+			return ValueTypeWithReferenceFieldsCache.GetOrAdd(type, IsValueTypeWithReferenceFieldsImpl);
+        }
+
+        private static bool IsValueTypeWithReferenceFieldsImpl(Type type)
+        {
+			if (!type.IsValueType) return false;
+			return type.GetProperties(GetBindingFlags(CacheBehaviour.IncludePrivate)).Any(x => x.PropertyType.IsClass);
+        }
+
+        internal static bool IsListType(Type type)
 		{
 			return IsListCache.GetOrAdd(type, IsListTypeImpl);
 		}


### PR DESCRIPTION
DefaultComparison have higher priority than ComplexComparison, and value types are checked using this comparison. However, due to `Equals` semantics for value types, if type contains field of reference type, fields are compared using referential equality.

Fix introduces check whether types compared are value types holding reference type fields in both DefaultComparison and ComplexComparison. Added a test to check this behavior; all tests green